### PR TITLE
Avoid nameclash with 

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -5,7 +5,7 @@
     "license": "BSD-3-Clause",
     "version": "1.0.0",
     "exposed-modules": [
-        "Uuid"
+        "Prng.Uuid"
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {

--- a/examples/Main.elm
+++ b/examples/Main.elm
@@ -3,8 +3,8 @@ module Main exposing (main)
 import Browser
 import Html exposing (Html, button, div, text)
 import Html.Events exposing (onClick)
+import Prng.Uuid as Uuid
 import Random.Pcg.Extended exposing (Seed, initialSeed, step)
-import Uuid
 
 
 

--- a/src/Prng/Uuid.elm
+++ b/src/Prng/Uuid.elm
@@ -1,4 +1,4 @@
-module Uuid exposing
+module Prng.Uuid exposing
     ( Uuid, generator, fromString, toString, encode, decoder
     , stringGenerator, isValidUuid
     )
@@ -47,9 +47,9 @@ Have a look at the examples in the package to see how to use it!
 
 import Json.Decode as JD
 import Json.Encode as JE
+import Prng.Uuid.Barebones as Barebones exposing (..)
 import Random.Pcg.Extended exposing (Generator, Seed, int, list, map, step)
 import String
-import Uuid.Barebones exposing (..)
 
 
 {-| Uuid type. Represents a 128 bit Uuid (Version 4)
@@ -126,7 +126,7 @@ stringGenerator =
 -}
 isValidUuid : String -> Bool
 isValidUuid =
-    Uuid.Barebones.isValidUuid
+    Barebones.isValidUuid
 
 
 

--- a/src/Prng/Uuid/Barebones.elm
+++ b/src/Prng/Uuid/Barebones.elm
@@ -1,4 +1,4 @@
-module Uuid.Barebones exposing (isValidUuid, toUuidString)
+module Prng.Uuid.Barebones exposing (isValidUuid, toUuidString)
 
 import Array
 import Bitwise

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -5,12 +5,12 @@ module Tests exposing (all, buildUuid, initialSeedFuzzer, randomInt, uuidFuzzer)
 
 import Expect
 import Fuzz
+import Prng.Uuid as Uuid exposing (..)
 import Random
 import Random.Pcg.Extended as RandomE
 import Shrink
 import String
 import Test exposing (..)
-import Uuid exposing (..)
 
 
 randomInt : Random.Generator Int


### PR DESCRIPTION
We're getting a name clash between this library and `danyx23/elm-uuid` (which is an indirect dependency of NRI). The error only shows up if you ran `scripts/generate-elm-doc.sh` (see https://github.com/NoRedInk/NoRedInk/pull/22253).
This PR prefixes `Uuid` with `Prng` (PCG-extended PRNG).